### PR TITLE
Handle container of blocks properly

### DIFF
--- a/Sources/CommonMarkAttributedString/CommonMark+AttributedStringConvertible.swift
+++ b/Sources/CommonMarkAttributedString/CommonMark+AttributedStringConvertible.swift
@@ -115,7 +115,11 @@ extension Heading {
 }
 
 extension List {
-    fileprivate var nestingLevel: Int {
+    func delimiter(at position: Int) -> String {
+      kind == .ordered ? "\(position + 1)." : "•"
+    }
+  
+    var nestingLevel: Int {
         sequence(first: self) { $0.parent }.map { ($0 is List) ? 1 : 0}.reduce(0, +)
     }
 
@@ -132,7 +136,7 @@ extension List.Item {
     // TODO: Represent lists with NSTextList on macOS
     fileprivate func attributedString(in list: List, at position: Int, attributes: [NSAttributedString.Key: Any], attachments: [String: NSTextAttachment]) throws -> NSAttributedString {
 
-        var delimiter: String = list.kind == .ordered ? "\(position + 1)." : "•"
+        var delimiter: String = list.delimiter(at: position)
         #if os(macOS) && canImport(AppKit)
         if #available(OSX 10.13, *) {
             let format: NSTextList.MarkerFormat

--- a/Sources/CommonMarkAttributedString/Components/CommonMark+ComponentListConvertible.swift
+++ b/Sources/CommonMarkAttributedString/Components/CommonMark+ComponentListConvertible.swift
@@ -20,24 +20,18 @@ extension Node: ComponentListConvertible {
   func makeComponents(with tokenizer: Tokenizer, attributes: [NSAttributedString.Key: Any]) throws -> [CommonMarkComponent] {
     switch self {
     case let container as ContainerOfBlocks:
-      guard !container.children.contains(where: { $0 is HTMLBlock }) else {
-        let html = try Document(container.description).render(format: .html)
-        let htmlString = try NSAttributedString(html: html, attributes: attributes) ?? NSAttributedString()
-        return [.simple(.string(htmlString))]
-      }
-      
-      let blockExtensionComponents = try parseExtension(
-        str: container.description.unescapedForCommonmark(),
-        attributes: attributes,
+      return try makeBlockContainerComponents(
+        for: container.description.unescapedForCommonmark(),
+        children: container.children,
         tokenizer: tokenizer,
-        type: .block,
-        with: tokenizer.blockExtension(from:))
+        attributes: attributes)
       
-      if !blockExtensionComponents.isEmpty {
-        return blockExtensionComponents
-      }
-      
-      return try container.children.flatMap { try $0.makeComponents(with: tokenizer, attributes: attributes) }
+    case let list as List:
+      return try makeListComponents(
+        for: list,
+        children: list.children,
+        tokenizer: tokenizer,
+        attributes: attributes)
       
     case let container as ContainerOfInlineElements:
       guard !container.children.contains(where: { $0 is RawHTML }) else {
@@ -71,6 +65,48 @@ extension Node: ComponentListConvertible {
   }
   
   // MARK: Private
+  
+  private func makeListComponents(
+    for list: List,
+    children: [List.Item],
+    tokenizer: Tokenizer,
+    attributes: [NSAttributedString.Key: Any]) throws -> [CommonMarkComponent]
+  {
+    return try children.enumerated().flatMap { offset, child -> [CommonMarkComponent] in
+      try child.makeListItemComponents(
+        in: list,
+        for: child,
+        at: offset,
+        with: tokenizer,
+        attributes: attributes)
+    }
+  }
+  
+  private func makeBlockContainerComponents(
+    for containerString: String,
+    children: [Node],
+    tokenizer: Tokenizer,
+    attributes: [NSAttributedString.Key: Any]) throws -> [CommonMarkComponent]
+  {
+    guard !children.contains(where: { $0 is HTMLBlock }) else {
+      let html = try Document(containerString).render(format: .html)
+      let htmlString = try NSAttributedString(html: html, attributes: attributes) ?? NSAttributedString()
+      return [.simple(.string(htmlString))]
+    }
+    
+    let blockExtensionComponents = try parseExtension(
+      str: containerString,
+      attributes: attributes,
+      tokenizer: tokenizer,
+      type: .block,
+      with: tokenizer.blockExtension(from:))
+    
+    if !blockExtensionComponents.isEmpty {
+      return blockExtensionComponents
+    }
+    
+    return try children.flatMap { try $0.makeComponents(with: tokenizer, attributes: attributes) }
+  }
   
   /// "Folds" the child elements into their `NSAttributedString`s when applicable, breaking them apart when images or extensions are encountered
   private func foldedComponents(
@@ -156,5 +192,35 @@ extension Node: ComponentListConvertible {
     }
     
     return textBeforeComponents + [.extension(component)] + textAfterComponents
+  }
+  
+  private func makeListItemComponents(
+    in list: List,
+    for item: List.Item,
+    at position: Int,
+    with tokenizer: Tokenizer,
+    attributes: [NSAttributedString.Key: Any]) throws -> [CommonMarkComponent]
+  {
+    var components = try item.children.flatMap { try $0.makeComponents(with: tokenizer, attributes: attributes) }
+    guard !components.isEmpty else {
+      return components
+    }
+    
+    let delimiter = list.delimiter(at: position)
+    let indentation = String(repeating: "\t", count: list.nestingLevel)
+    let mutableAttributedString = NSMutableAttributedString(string: indentation + delimiter + " ", attributes: attributes)
+    
+    let originalFirst = components.removeFirst()
+    switch originalFirst {
+    case .extension, .simple(.url):
+      components.insert(originalFirst, at: 0)
+      components.insert(.simple(.string(mutableAttributedString)), at: 0)
+      return components
+    case .simple(.string(let str)):
+      mutableAttributedString.append(str)
+      components.insert(.simple(.string(mutableAttributedString)), at: 0)
+    }
+    
+    return components
   }
 }

--- a/Sources/CommonMarkAttributedString/Components/CommonMarkComponentList.swift
+++ b/Sources/CommonMarkAttributedString/Components/CommonMarkComponentList.swift
@@ -15,7 +15,7 @@ public enum CommonMarkComponent: Hashable {
 public struct ExtensionComponent: Hashable {
   public let type: ExtensionType
   public let name: String
-  public let components: [SimpleCommonMarkComponent]
+  public let components: [CommonMarkComponent]
   public let argument: String
   public let properties: [String: String]
 }

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
@@ -278,4 +278,45 @@ final class CommonMarkComponentListTests: XCTestCase {
       XCTFail("Expected .simple(.string)) to be the fourth component")
     }
   }
+  
+  func testBlockWithNoPropertiesAndTextAfter() throws {
+    let commonmark = "FamilyCallout: Learning Connections\n:::\nIn this project, learners will practice problem solving skills, and gain exposure to physical science concepts. They will:\n- Analyze and test different materials to determine which materials have the properties that are best suited for an intended purpose\n- Conduct an investigation to compare the effects of different forces on the motion of an object\n- Determine if a design solution works as intended to change the speed or direction of an object with a push or pull\n- Practice resourcefulness, by finding ways to use the supplies they have available to solve a given problem\n:::\n\nFor this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).  \n\nHere are the rules you must follow:\n\n- Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\n\n- The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\n\n- You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\n\n**To get started, explore your home and look for recyclables or other materials you could use for building your device.** \n\n"
+    
+    #if canImport(UIKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 24.0),
+        .foregroundColor: UIColor.systemBlue
+    ]
+    #elseif canImport(AppKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 24.0),
+        .foregroundColor: NSColor.systemBlue
+    ]
+    #endif
+
+    let components = try CommonMarkComponentList(
+      commonmark: commonmark,
+      attributes: attributes).components
+
+    XCTAssertEqual(components.count, 5)
+    
+    if case .extension(let ext) = components.first {
+      XCTAssertEqual(ext.type, .block)
+      XCTAssertEqual(ext.components.count, 2)
+    } else {
+      XCTFail("Expected .extension with a type of .block to be the first component in \(components)")
+    }
+    
+    if case .simple(.string(let str)) = components.dropFirst().first {
+      XCTAssertEqual(str.string, "For this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the second component")
+    }
+    
+    if case .simple(.string(let str)) = components.dropFirst(2).first {
+      XCTAssertEqual(str.string, "Here are the rules you must follow:")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the third component")
+    }
+  }
 }

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
@@ -407,4 +407,48 @@ final class CommonMarkComponentListTests: XCTestCase {
       XCTFail("Expected .simple(.url) to be the second component in \(components)")
     }
   }
+  
+  func testListItemImageOnly() throws {
+    let commonmark = """
+    1. ![](https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788011/upg8sag6kgtpt8vqos1s.png)
+    1. Roll it around your straw
+    """
+
+    #if canImport(UIKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 24.0),
+        .foregroundColor: UIColor.systemBlue
+    ]
+    #elseif canImport(AppKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 24.0),
+        .foregroundColor: NSColor.systemBlue
+    ]
+    #endif
+
+    let components = try CommonMarkComponentList(
+      commonmark: commonmark,
+      attributes: attributes).components
+
+    XCTAssertEqual(components.count, 3)
+
+    if case .simple(.string(let str)) = components.first {
+      XCTAssertEqual(str.string, "\t1. ")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the first component")
+    }
+
+    if case .simple(.url(let url)) = components.dropFirst().first {
+      XCTAssertEqual(url.absoluteString, "https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788011/upg8sag6kgtpt8vqos1s.png")
+    } else {
+      XCTFail("Expected .simple(.url) to be the second component in \(components)")
+    }
+
+    if case .simple(.string(let str)) = components.dropFirst(2).first {
+      XCTAssertEqual(str.string, "\t2. Roll it around your straw")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the third component")
+    }
+  }
+
 }

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
@@ -298,11 +298,11 @@ final class CommonMarkComponentListTests: XCTestCase {
       commonmark: commonmark,
       attributes: attributes).components
 
-    XCTAssertEqual(components.count, 5)
+    XCTAssertEqual(components.count, 7)
     
     if case .extension(let ext) = components.first {
       XCTAssertEqual(ext.type, .block)
-      XCTAssertEqual(ext.components.count, 2)
+      XCTAssertEqual(ext.components.count, 5)
     } else {
       XCTFail("Expected .extension with a type of .block to be the first component in \(components)")
     }
@@ -317,6 +317,94 @@ final class CommonMarkComponentListTests: XCTestCase {
       XCTAssertEqual(str.string, "Here are the rules you must follow:")
     } else {
       XCTFail("Expected .simple(.string)) to be the third component")
+    }
+  }
+  
+  func testPreserveStandardList() throws {
+    let commonmark = """
+    1. Cut a piece of paper into a 1.5\" x 11\" strip.
+    1. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project.
+    """
+
+    #if canImport(UIKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 24.0),
+        .foregroundColor: UIColor.systemBlue
+    ]
+    #elseif canImport(AppKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 24.0),
+        .foregroundColor: NSColor.systemBlue
+    ]
+    #endif
+
+    let components = try CommonMarkComponentList(
+      commonmark: commonmark,
+      attributes: attributes).components
+
+    XCTAssertEqual(components.count, 2)
+
+    if case .simple(.string(let str)) = components.first {
+      XCTAssertEqual(str.string, "\t1. Cut a piece of paper into a 1.5\" x 11\" strip.")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the first component")
+    }
+    
+    if case .simple(.string(let str)) = components.dropFirst().first {
+      XCTAssertEqual(str.string, "\t2. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project.")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the first component")
+    }
+  }
+  
+  func testListItemWithImage() throws {
+    let commonmark = """
+    1. Cut a piece of paper into a 1.5\" x 11\" strip.
+    ![](https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788011/upg8sag6kgtpt8vqos1s.png)
+    1. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project.
+    ![](https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788024/wbgdryijgfagcyqscl2b.png)
+    """
+
+    #if canImport(UIKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 24.0),
+        .foregroundColor: UIColor.systemBlue
+    ]
+    #elseif canImport(AppKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 24.0),
+        .foregroundColor: NSColor.systemBlue
+    ]
+    #endif
+
+    let components = try CommonMarkComponentList(
+      commonmark: commonmark,
+      attributes: attributes).components
+
+    XCTAssertEqual(components.count, 4)
+
+    if case .simple(.string(let str)) = components.first {
+      XCTAssertEqual(str.string, "\t1. Cut a piece of paper into a 1.5\" x 11\" strip. ")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the first component")
+    }
+
+    if case .simple(.url(let url)) = components.dropFirst().first {
+      XCTAssertEqual(url.absoluteString, "https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788011/upg8sag6kgtpt8vqos1s.png")
+    } else {
+      XCTFail("Expected .simple(.url) to be the second component in \(components)")
+    }
+
+    if case .simple(.string(let str)) = components.dropFirst(2).first {
+      XCTAssertEqual(str.string, "\t2. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project. ")
+    } else {
+      XCTFail("Expected .simple(.string)) to be the first component")
+    }
+
+    if case .simple(.url(let url)) = components.dropFirst(3).first {
+      XCTAssertEqual(url.absoluteString, "https://res.cloudinary.com/primer-cloudinary/image/upload/v1599788024/wbgdryijgfagcyqscl2b.png")
+    } else {
+      XCTFail("Expected .simple(.url) to be the second component in \(components)")
     }
   }
 }

--- a/Tests/CommonMarkAttributedStringTests/TokenizerTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/TokenizerTests.swift
@@ -229,4 +229,20 @@ final class TokenizerTests: XCTestCase {
 
     XCTAssertEqual(actual, expected)
   }
+  
+  func testBlockWithNoPropertiesAndTextAfter() throws {
+    let block = "FamilyCallout: Learning Connections\n:::\nIn this project, learners will practice problem solving skills, and gain exposure to physical science concepts. They will:\n- Analyze and test different materials to determine which materials have the properties that are best suited for an intended purpose\n- Conduct an investigation to compare the effects of different forces on the motion of an object\n- Determine if a design solution works as intended to change the speed or direction of an object with a push or pull\n- Practice resourcefulness, by finding ways to use the supplies they have available to solve a given problem\n:::\n\nFor this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).  \n\nHere are the rules you must follow:\n\n- Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\n\n- The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\n\n- You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\n\n**To get started, explore your home and look for recyclables or other materials you could use for building your device.** \n\n"
+    
+    let actual = try Tokenizer().blockExtension(from: block)
+    let expected = Extension(
+      textBefore: "",
+      textAfter: "\n\nFor this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).  \n\nHere are the rules you must follow:\n\n- Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\n\n- The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\n\n- You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\n\n**To get started, explore your home and look for recyclables or other materials you could use for building your device.** \n",
+      type: .block,
+      name: "FamilyCallout",
+      content: "In this project, learners will practice problem solving skills, and gain exposure to physical science concepts. They will:\n- Analyze and test different materials to determine which materials have the properties that are best suited for an intended purpose\n- Conduct an investigation to compare the effects of different forces on the motion of an object\n- Determine if a design solution works as intended to change the speed or direction of an object with a push or pull\n- Practice resourcefulness, by finding ways to use the supplies they have available to solve a given problem",
+      argument: "Learning Connections",
+      properties: [:])
+
+    XCTAssertEqual(actual, expected)
+  }
 }

--- a/Tests/CommonMarkAttributedStringTests/UnescapedTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/UnescapedTests.swift
@@ -17,9 +17,9 @@ import AppKit
 
 @testable import CommonMarkAttributedString
 
-/// All tests here are taken from the [official spec](https://spec.commonmark.org/0.29/#backslash-escapes)
+/// All tests here that are named after examples are taken from the [official spec](https://spec.commonmark.org/0.29/#backslash-escapes)
 final class UnescapedTests: XCTestCase {
-  
+    
   // 298: Any ASCII punctuation character may be backslash-escaped
   func test_example298() throws {
     let str = #"\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~"#
@@ -80,4 +80,10 @@ final class UnescapedTests: XCTestCase {
     XCTAssertThrowsError(try str.unescapedForCommonmark(), "```foo+bar\nfoo```")
   }
   // 🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+  
+  func test_ProdFamilyGuide() throws {
+    let str = "FamilyCallout: Learning Connections\n:::\nIn this project, learners will practice problem solving skills, and gain exposure to physical science concepts. They will:\n- Analyze and test different materials to determine which materials have the properties that are best suited for an intended purpose\n- Conduct an investigation to compare the effects of different forces on the motion of an object\n- Determine if a design solution works as intended to change the speed or direction of an object with a push or pull\n- Practice resourcefulness, by finding ways to use the supplies they have available to solve a given problem\n:::\n\nFor this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).  \n\nHere are the rules you must follow:\n\n- Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\n\n- The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\n\n- You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\n\n**To get started, explore your home and look for recyclables or other materials you could use for building your device.** \n\n"
+
+    XCTAssertEqual(try str.unescapedForCommonmark(), "FamilyCallout: Learning Connections\n:::\nIn this project, learners will practice problem solving skills, and gain exposure to physical science concepts. They will:\n- Analyze and test different materials to determine which materials have the properties that are best suited for an intended purpose\n- Conduct an investigation to compare the effects of different forces on the motion of an object\n- Determine if a design solution works as intended to change the speed or direction of an object with a push or pull\n- Practice resourcefulness, by finding ways to use the supplies they have available to solve a given problem\n:::\n\nFor this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).  \n\nHere are the rules you must follow:\n\n- Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\n\n- The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\n\n- You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\n\n**To get started, explore your home and look for recyclables or other materials you could use for building your device.** \n\n")
+  }
 }


### PR DESCRIPTION
- [x] We need to take care of block extensions before the parser breaks them up into their respective inlines
- [x] We need to carry over the special list item logic that the library does