### PR TITLE
Fix string component joining

### DIFF
--- a/Sources/CommonMarkAttributedString/Components/CommonMark+ComponentListConvertible.swift
+++ b/Sources/CommonMarkAttributedString/Components/CommonMark+ComponentListConvertible.swift
@@ -24,14 +24,14 @@ extension Node: ComponentListConvertible {
         for: container.description.unescapedForCommonmark(),
         children: container.children,
         tokenizer: tokenizer,
-        attributes: attributes)
+        attributes: attributes).joined(separator: "\u{2029}")
       
     case let list as List:
       return try makeListComponents(
         for: list,
         children: list.children,
         tokenizer: tokenizer,
-        attributes: attributes)
+        attributes: attributes).joined(separator: "\u{2029}")
       
     case let container as ContainerOfInlineElements:
       guard !container.children.contains(where: { $0 is RawHTML }) else {
@@ -43,11 +43,13 @@ extension Node: ComponentListConvertible {
         for: container.description.unescapedForCommonmark(),
         children: container.children,
         tokenizer: tokenizer,
-        attributes: attributes)
+        attributes: attributes).joined()
       
     default:
       let simpleComponents = try makeSimpleComponents(attributes: attributes)
-      return simpleComponents.map { .simple($0) }
+      return simpleComponents
+        .map { .simple($0) }
+        .joined(separator: "\u{2029}")
     }
   }
   

--- a/Sources/CommonMarkAttributedString/Components/Components+Joined.swift
+++ b/Sources/CommonMarkAttributedString/Components/Components+Joined.swift
@@ -1,0 +1,49 @@
+//
+//  Components+Joined.swift
+//  CommonMarkAttributedString
+//
+//  Created by Gonzalo Nunez on 9/29/20.
+//
+
+#if canImport(AppKit)
+import class AppKit.NSAttributedString
+import class AppKit.NSMutableAttributedString
+#elseif canImport(UIKit)
+import class UIKit.NSAttributedString
+import class UIKit.NSMutableAttributedString
+#endif
+
+extension Array where Element == CommonMarkComponent {
+  
+  func joined(separator: String? = nil) -> [CommonMarkComponent] {
+    guard let first = first else { return [] }
+    guard count > 1 else { return [first] }
+    
+    return suffix(from: startIndex.advanced(by: 1)).reduce(into: [first]) { components, component in
+      switch component {
+      case .extension(let extensionComponent):
+        let joinedExtension = ExtensionComponent(
+          type: extensionComponent.type,
+          name: extensionComponent.name,
+          components: extensionComponent.components.joined(),
+          argument: extensionComponent.argument,
+          properties: extensionComponent.properties)
+        components.append(.extension(joinedExtension))
+      case .simple(let simpleComponent):
+        switch simpleComponent {
+        case .string(let attributedString):
+          switch components.last {
+          case .simple(.string(let existingAttributedString))?:
+            components.removeLast()
+            let newString = [existingAttributedString, attributedString].joined(separator: separator)
+            components.append(.simple(.string(newString)))
+          default:
+            components.append(.simple(.string(attributedString)))
+          }
+        case .url(let url):
+          components.append(.simple(.url(url)))
+        }
+      }
+    }
+  }
+}

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkComponentListTests.swift
@@ -196,7 +196,7 @@ final class CommonMarkComponentListTests: XCTestCase {
       commonmark: commonmark,
       attributes: attributes).components
 
-    XCTAssertEqual(components.count, 4)
+    XCTAssertEqual(components.count, 3)
 
     if case .simple(.string(let str)) = components.first {
       XCTAssertEqual(str.string, "Some text beforehand!")
@@ -211,15 +211,9 @@ final class CommonMarkComponentListTests: XCTestCase {
     }
     
     if case .simple(.string(let str)) = components.dropFirst(2).first {
-      XCTAssertEqual(str.string, "Testing test test")
+      XCTAssertEqual(str.string, "Testing test test\u{2029}HELLO")
     } else {
       XCTFail("Expected .simple(.string)) to be the third component")
-    }
-    
-    if case .simple(.string(let str)) = components.dropFirst(3).first {
-      XCTAssertEqual(str.string, "HELLO")
-    } else {
-      XCTFail("Expected .simple(.string)) to be the fourth component")
     }
   }
   
@@ -252,7 +246,7 @@ final class CommonMarkComponentListTests: XCTestCase {
       commonmark: commonmark,
       attributes: attributes).components
 
-    XCTAssertEqual(components.count, 4)
+    XCTAssertEqual(components.count, 3)
 
     if case .simple(.string(let str)) = components.first {
       XCTAssertEqual(str.string, "Testing test test Some text beforehand!")
@@ -267,15 +261,9 @@ final class CommonMarkComponentListTests: XCTestCase {
     }
     
     if case .simple(.string(let str)) = components.dropFirst(2).first {
-      XCTAssertEqual(str.string, "And some text after!")
+      XCTAssertEqual(str.string, "And some text after!\u{2029}HELLO WORLD BIG HEADER")
     } else {
       XCTFail("Expected .simple(.string)) to be the third component")
-    }
-    
-    if case .simple(.string(let str)) = components.dropFirst(3).first {
-      XCTAssertEqual(str.string, "HELLO WORLD BIG HEADER")
-    } else {
-      XCTFail("Expected .simple(.string)) to be the fourth component")
     }
   }
   
@@ -298,25 +286,19 @@ final class CommonMarkComponentListTests: XCTestCase {
       commonmark: commonmark,
       attributes: attributes).components
 
-    XCTAssertEqual(components.count, 7)
+    XCTAssertEqual(components.count, 2)
     
     if case .extension(let ext) = components.first {
       XCTAssertEqual(ext.type, .block)
-      XCTAssertEqual(ext.components.count, 5)
+      XCTAssertEqual(ext.components.count, 1)
     } else {
       XCTFail("Expected .extension with a type of .block to be the first component in \(components)")
     }
     
     if case .simple(.string(let str)) = components.dropFirst().first {
-      XCTAssertEqual(str.string, "For this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).")
+      XCTAssertEqual(str.string, "For this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).\u{2029}Here are the rules you must follow:\u{2029}\t• Your device must be dropped with the egg; you can't build anything on the ground for the egg to land on.\u{2029}\t• The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!\u{2029}\t• You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.\u{2029}To get started, explore your home and look for recyclables or other materials you could use for building your device.")
     } else {
       XCTFail("Expected .simple(.string)) to be the second component")
-    }
-    
-    if case .simple(.string(let str)) = components.dropFirst(2).first {
-      XCTAssertEqual(str.string, "Here are the rules you must follow:")
-    } else {
-      XCTFail("Expected .simple(.string)) to be the third component")
     }
   }
   
@@ -342,16 +324,10 @@ final class CommonMarkComponentListTests: XCTestCase {
       commonmark: commonmark,
       attributes: attributes).components
 
-    XCTAssertEqual(components.count, 2)
+    XCTAssertEqual(components.count, 1)
 
     if case .simple(.string(let str)) = components.first {
-      XCTAssertEqual(str.string, "\t1. Cut a piece of paper into a 1.5\" x 11\" strip.")
-    } else {
-      XCTFail("Expected .simple(.string)) to be the first component")
-    }
-    
-    if case .simple(.string(let str)) = components.dropFirst().first {
-      XCTAssertEqual(str.string, "\t2. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project.")
+      XCTAssertEqual(str.string, "\t1. Cut a piece of paper into a 1.5\" x 11\" strip.\u{2029}\t2. Roll it around your straw and tape it in three places to hold it's shape. The straw shown here is a paper straw made using the instructions in a prior step of this project.")
     } else {
       XCTFail("Expected .simple(.string)) to be the first component")
     }
@@ -451,4 +427,37 @@ final class CommonMarkComponentListTests: XCTestCase {
     }
   }
 
+  func testPreservesNewlinesWithCorrectSeparator() throws {
+    let commonmark = """
+    For this project you will invent a device that keeps an egg from cracking when it is dropped from 7 feet high (or higher!).
+
+    Here are the rules you must follow:
+
+    - Your device must be dropped with the egg; you can\'t build anything on the ground for the egg to land on.
+    
+    - The floor must be hard, like in a kitchen or outside on a sidewalk or thin grass. No dropping it on carpet!
+
+    - You must prevent the egg from making a mess if your invention fails. Lay down some trash bags where you drop it to catch any mess you might make.
+
+    **To get started, explore your home and look for recyclables or other materials you could use for building your device.**
+    """
+    
+    #if canImport(UIKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 24.0),
+        .foregroundColor: UIColor.systemBlue
+    ]
+    #elseif canImport(AppKit)
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 24.0),
+        .foregroundColor: NSColor.systemBlue
+    ]
+    #endif
+
+    let components = try CommonMarkComponentList(
+      commonmark: commonmark,
+      attributes: attributes).components
+
+    XCTAssertEqual(components.count, 1)
+  }
 }


### PR DESCRIPTION
We were not "joining" components at the outer-most level correctly. This now adds a final step to the algorithm, that does what we're doing in `foldedComponents` but at the end as well, _across_ `CommonMarkComponent`s and not just within them.

Take the following markdown into account:
```markdown
This is some text
### This is a header
```

Prior to this change, we'd output the following **two** components (and even had it backed by tests!):
```
[
  .string(This is some text),
  .string(This is a header),
]
```

However, this is not entirely correct – we want to let the markdown handle as much as possible. We want to _join_ every possible string together, so we end up with something like this:
```
[
  .string(This is some text\u{2029}This is a header),
]
```

We still want things split when we encounter an image or an extensions, that behavior has been preserved and we're accounting for it on our unit tests.